### PR TITLE
Enforce stricter type bans, relax rules for tests

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -190,12 +190,20 @@ export const config = [
 
       // Hard bans for TS escape hatches
       // (These will be relaxed for tests and JS files later in this config.)
+      // Uses :has/:matches selectors; requires ESLint 8.45+ (esquery 1.5+) support.
       'no-restricted-syntax': [
         ERROR,
         {
-          selector: 'TSAsExpression[expression.type="TSAsExpression"]',
+          selector:
+            ':matches(TSAsExpression, TSTypeAssertion):has(> :matches(TSAsExpression, TSTypeAssertion))',
           message:
-            'Double casts (e.g. x as unknown as T) are banned – use validation, generics, or a typed adapter instead.',
+            'Double casts (e.g. x as unknown as T or <T>(x as unknown)) are banned – use validation, generics, or a typed adapter instead.',
+        },
+        {
+          selector:
+            ':matches(TSAsExpression, TSTypeAssertion):has(> :matches(ParenthesizedExpression, TSNonNullExpression):has(:matches(TSAsExpression, TSTypeAssertion)))',
+          message:
+            'Double casts (including parentheses or non-null wrappers, e.g. (x as unknown)! as T) are banned – use validation, generics, or a typed adapter instead.',
         },
       ],
 

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -36,7 +36,9 @@ const testFiles = [
   '**/__tests__/**',
   '**/*.test.*',
   '**/*.spec.*',
-  '**/test-data.ts',
+  '**/test-data.*',
+  '**/test-data/**',
+  '**/{fixtures,fixture,mocks,__mocks__,mock-data,stubs}/**',
 ];
 
 const playwrightFiles = ['**/e2e/**'];

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -219,6 +219,18 @@ export const config = [
     languageOptions: { globals: { Bun: true } },
   },
 
+  hasTypeScript
+    ? {
+        files: ['**/*.ts?(x)'],
+        rules: {
+          '@typescript-eslint/consistent-type-assertions': ERROR,
+          '@typescript-eslint/no-explicit-any': ERROR,
+          '@typescript-eslint/no-non-null-assertion': ERROR,
+          '@typescript-eslint/no-unnecessary-type-assertion': ERROR,
+        },
+      }
+    : null,
+
   // React settings (if present)
   hasReact
     ? {
@@ -383,12 +395,6 @@ export const config = [
           ],
           '@typescript-eslint/unified-signatures': ERROR,
           'import/consistent-type-specifier-style': [ERROR, 'prefer-inline'],
-
-          // Stricter type constraints
-          '@typescript-eslint/consistent-type-assertions': ERROR,
-          '@typescript-eslint/no-explicit-any': ERROR,
-          '@typescript-eslint/no-non-null-assertion': ERROR,
-          '@typescript-eslint/no-unnecessary-type-assertion': ERROR,
 
           // Disable rules from presets
           '@typescript-eslint/consistent-type-definitions': 'off',


### PR DESCRIPTION
Adds hard bans on double casts, stricter type assertion rules,
and disables these for tests and JS files. Expands test file
patterns and tightens rules for TypeScript code by default.
